### PR TITLE
Add Bruker SPC binary format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
 
 add_library(xy
             xylib/bruker_raw.cpp
+            xylib/bruker_spc.cpp
             xylib/cache.cpp
             xylib/canberra_cnf.cpp
             xylib/canberra_mca.cpp

--- a/xylib/Makefile.am
+++ b/xylib/Makefile.am
@@ -4,14 +4,14 @@ lib_LTLIBRARIES = libxy.la
 libxy_la_LDFLAGS = -no-undefined -version-info 4:1:1
 libxy_la_LIBADD = $(XYLIB_ADDLIB)
 
-libxy_la_SOURCES = xylib.cpp cache.cpp bruker_raw.cpp \
+libxy_la_SOURCES = xylib.cpp cache.cpp bruker_raw.cpp bruker_spc.cpp \
 		   pdcif.cpp philips_raw.cpp philips_udf.cpp \
 		   xrdml.cpp rigaku_dat.cpp text.cpp csv.cpp \
 		   uxd.cpp vamas.cpp winspec_spe.cpp cpi.cpp dbws.cpp \
 		   canberra_mca.cpp canberra_cnf.cpp xfit_xdd.cpp riet7.cpp \
 		   chiplot.cpp spectra.cpp specsxy.cpp util.cpp util.h
 
-pkginclude_HEADERS = xylib.h cache.h bruker_raw.h \
+pkginclude_HEADERS = xylib.h cache.h bruker_raw.h bruker_spc.h\
   		     pdcif.h philips_raw.h philips_udf.h xrdml.h \
 		     rigaku_dat.h text.h csv.h uxd.h vamas.h winspec_spe.h \
 		     cpi.h dbws.h canberra_mca.h canberra_cnf.h \

--- a/xylib/bruker_spc.cpp
+++ b/xylib/bruker_spc.cpp
@@ -8,7 +8,6 @@
 #include "bruker_spc.h"
 #include <sstream>
 #include "util.h"
-#include "Rcpp.h"
 
 using namespace std;
 using namespace xylib::util;

--- a/xylib/bruker_spc.cpp
+++ b/xylib/bruker_spc.cpp
@@ -1,0 +1,80 @@
+// Bruker ESP300-E raw binary spectrum
+// Licence: Lesser GNU Public License 2.1 (LGPL)
+// Implementation based on work by Christoph Burow done for his R package 'ESR'
+// https://github.com/tzerk/ESR
+// Implementation carried out by Sebastian Kreutzer, IRAMAT-CRP2A, Universite Bordeaux Montaigne, France
+
+#define BUILDING_XYLIB
+#include "bruker_spc.h"
+#include <sstream>
+#include "util.h"
+#include "Rcpp.h"
+
+using namespace std;
+using namespace xylib::util;
+
+namespace xylib {
+
+const FormatInfo BrukerSpcDataSet::fmt_info(
+    "bruker_spc",
+    "Bruker ESP300-E SPC",
+    "spc",
+    true,                        // whether binary
+    false,                       // whether has multi-blocks
+    &BrukerSpcDataSet::ctor,
+    &BrukerSpcDataSet::check
+);
+
+bool BrukerSpcDataSet::check(std::istream &f, string*)
+{
+
+  return true;
+}
+
+
+void BrukerSpcDataSet::load_data(std::istream &f)
+{
+  Block* blk = new Block;
+
+  //predefine vectors
+  VecColumn *xcol = new VecColumn;
+  VecColumn *ycol = new VecColumn;
+
+  //initialise values
+  int channel = 1;
+  int stop = 0;
+
+  //run the import until we struggle
+  while (stop == 0) {
+
+    //we only try
+    try{
+
+      //the file format is quite simple, however,
+      //we have BIG endian, means we have to swap the byte position ...
+      //https://stackoverflow.com/questions/105252/how-do-i-convert-between-big-endian-and-little-endian-values-in-c#105339
+      int y = __builtin_bswap32 ((int32_t) read_uint32_le(f));
+      ycol -> add_val(y);
+
+      //set x-value and update channel number
+      xcol -> add_val(channel);
+      channel++;
+
+    }
+
+    //catch the expection and set stop to 1
+    catch (const exception& e) {
+      stop = 1;
+    }
+
+  }
+
+  //add block data
+  blk->add_column(xcol);
+  blk->add_column(ycol);
+  add_block(blk);
+
+}
+
+} // end of namespace xylib
+

--- a/xylib/bruker_spc.cpp
+++ b/xylib/bruker_spc.cpp
@@ -53,7 +53,7 @@ void BrukerSpcDataSet::load_data(std::istream &f)
       //the file format is quite simple, however,
       //we have BIG endian, means we have to swap the byte position ...
       //https://stackoverflow.com/questions/105252/how-do-i-convert-between-big-endian-and-little-endian-values-in-c#105339
-      int y = __builtin_bswap32 ((int32_t) read_uint32_le(f));
+      int y = __builtin_bswap32 ((__int32_t) read_uint32_le(f));
       ycol -> add_val(y);
 
       //set x-value and update channel number

--- a/xylib/bruker_spc.cpp
+++ b/xylib/bruker_spc.cpp
@@ -53,7 +53,7 @@ void BrukerSpcDataSet::load_data(std::istream &f)
       //the file format is quite simple, however,
       //we have BIG endian, means we have to swap the byte position ...
       //https://stackoverflow.com/questions/105252/how-do-i-convert-between-big-endian-and-little-endian-values-in-c#105339
-      int y = __builtin_bswap32 ((__int32_t) read_uint32_le(f));
+      int y = __builtin_bswap32 ((int32_t) read_uint32_le(f));
       ycol -> add_val(y);
 
       //set x-value and update channel number

--- a/xylib/bruker_spc.cpp
+++ b/xylib/bruker_spc.cpp
@@ -7,7 +7,7 @@
 #define BUILDING_XYLIB
 #include "bruker_spc.h"
 #include <sstream>
-#include <stdint>
+#include <cstdint>
 #include "util.h"
 
 using namespace std;

--- a/xylib/bruker_spc.cpp
+++ b/xylib/bruker_spc.cpp
@@ -7,7 +7,6 @@
 #define BUILDING_XYLIB
 #include "bruker_spc.h"
 #include <sstream>
-#include <cstdint>
 #include "util.h"
 
 using namespace std;
@@ -23,6 +22,7 @@ const FormatInfo BrukerSpcDataSet::fmt_info(
     false,                       // whether has multi-blocks
     &BrukerSpcDataSet::ctor,
     &BrukerSpcDataSet::check
+
 );
 
 bool BrukerSpcDataSet::check(std::istream &f, string*)
@@ -34,6 +34,8 @@ bool BrukerSpcDataSet::check(std::istream &f, string*)
 
 void BrukerSpcDataSet::load_data(std::istream &f)
 {
+
+
   Block* blk = new Block;
 
   //predefine vectors
@@ -52,8 +54,7 @@ void BrukerSpcDataSet::load_data(std::istream &f)
 
       //the file format is quite simple, however,
       //we have BIG endian, means we have to swap the byte position ...
-      //https://stackoverflow.com/questions/105252/how-do-i-convert-between-big-endian-and-little-endian-values-in-c#105339
-      int y = __builtin_bswap32 ((int32_t) read_uint32_le(f));
+      int y = swap_int32(read_int32_le(f));
       ycol -> add_val(y);
 
       //set x-value and update channel number

--- a/xylib/bruker_spc.cpp
+++ b/xylib/bruker_spc.cpp
@@ -7,6 +7,7 @@
 #define BUILDING_XYLIB
 #include "bruker_spc.h"
 #include <sstream>
+#include <stdint>
 #include "util.h"
 
 using namespace std;

--- a/xylib/bruker_spc.h
+++ b/xylib/bruker_spc.h
@@ -1,0 +1,23 @@
+// Bruker ESP300-E raw binary spectrum
+// Licence: Lesser GNU Public License 2.1 (LGPL)
+
+// The implementation based on a function written by Christoph Burow
+// https://github.com/tzerk/ESR/blob/master/R/read_Spectrum.R
+
+#ifndef XYLIB_BRUKER_SPC_H_
+#define XYLIB_BRUKER_SPC_H_
+
+#include "xylib.h"
+
+namespace xylib {
+
+    class BrukerSpcDataSet : public DataSet
+    {
+        OBLIGATORY_DATASET_MEMBERS(BrukerSpcDataSet)
+
+    };
+
+} // namespace
+
+#endif // XYLIB_BRUKER_SPC_H_
+

--- a/xylib/util.cpp
+++ b/xylib/util.cpp
@@ -453,7 +453,7 @@ void VecColumn::calculate_min_max() const
 //for all cases
 //https://stackoverflow.com/questions/2182002/convert-big-endian-to-little-endian-in-c-without-using-provided-func#2182184
 //! Byte swap int
-int32_t swap_int32( int32_t val )
+int32_t swap_int32(int32_t val)
 {
   val = ((val << 8) & 0xFF00FF00) | ((val >> 8) & 0xFF00FF );
   return (val << 16) | ((val >> 16) & 0xFFFF);

--- a/xylib/util.cpp
+++ b/xylib/util.cpp
@@ -97,6 +97,7 @@ T read_le(istream &f)
 }
 
 unsigned int read_uint32_le(istream &f) { return read_le<uint32_t>(f); }
+int read_int32_le(istream &f) { return read_le<int32_t>(f); } //SK: Added for signed integer
 unsigned int read_uint16_le(istream &f) { return read_le<uint16_t>(f); }
 int read_int16_le(istream &f) { return read_le<int16_t>(f); }
 float read_flt_le(istream &f) { return read_le<float>(f); }
@@ -445,6 +446,17 @@ void VecColumn::calculate_min_max() const
             max_val = *i;
     }
     last_minmax_length = data.size();
+}
+
+//SK:
+//we need byte swapping, howver, the preferred __builtin_bswap32 does not work
+//for all cases
+//https://stackoverflow.com/questions/2182002/convert-big-endian-to-little-endian-in-c-without-using-provided-func#2182184
+//! Byte swap int
+int32_t swap_int32( int32_t val )
+{
+  val = ((val << 8) & 0xFF00FF00) | ((val >> 8) & 0xFF00FF );
+  return (val << 16) | ((val >> 16) & 0xFFFF);
 }
 
 

--- a/xylib/util.h
+++ b/xylib/util.h
@@ -203,14 +203,15 @@ public:
     }
 };
 
+/// SK: Add declaration of swapping of signed integer binaries
+int swap_int32(int val);
+
 #if __cplusplus-0 < 201103L
 typedef std::auto_ptr<Block> AutoPtrBlock;
 #else
 typedef std::unique_ptr<Block> AutoPtrBlock;
 #endif
 
-/// SK: Add declaration of swapping of signed integer binaries
-int32_t swap_int32( int32_t val);
 
 } } // namespace xylib::util
 

--- a/xylib/util.h
+++ b/xylib/util.h
@@ -24,6 +24,7 @@ namespace xylib { namespace util {
 void le_to_host(void *ptr, int size);
 
 unsigned int read_uint32_le(std::istream &f);
+int read_int32_le(std::istream &f);
 unsigned int read_uint16_le(std::istream &f);
 int read_int16_le(std::istream &f);
 float read_flt_le(std::istream &f);
@@ -207,6 +208,9 @@ typedef std::auto_ptr<Block> AutoPtrBlock;
 #else
 typedef std::unique_ptr<Block> AutoPtrBlock;
 #endif
+
+/// SK: Add declaration of swapping of signed integer binaries
+int32_t swap_int32( int32_t val);
 
 } } // namespace xylib::util
 

--- a/xylib/xylib.cpp
+++ b/xylib/xylib.cpp
@@ -27,6 +27,7 @@
 
 #include "util.h"
 #include "bruker_raw.h"
+#include "bruker_spc.h"
 #include "rigaku_dat.h"
 #include "text.h"
 #include "csv.h"
@@ -68,6 +69,7 @@ const FormatInfo *formats[] = {
     &UxdDataSet::fmt_info,
     &RigakuDataSet::fmt_info,
     &BrukerRawDataSet::fmt_info,
+    &BrukerSpcDataSet::fmt_info,
     &VamasDataSet::fmt_info,
     &UdfDataSet::fmt_info,
     &WinspecSpeDataSet::fmt_info,
@@ -436,7 +438,7 @@ struct decompressing_istreambuf : public std::streambuf
         writeptr_ = bufdata_;
     }
 
-    // should be called only when the buffer is full, double the buffer size 
+    // should be called only when the buffer is full, double the buffer size
     void double_buf()
     {
         int old_size = (int) (writeptr_ - bufdata_);


### PR DESCRIPTION
Hi Marcin, 

as announced I've implemented the SPC file format in the 'xylib'.
However, there is one important thing that should be kept in mind: 
The data format consists of two files: 

* The binary file (SPC)
* An ASCII metadata file (PAR), e.g., https://github.com/tzerk/ESR/blob/master/inst/extdata/mollusc.PAR

So far I can see it, it would be necessary to test whether such file exists along with the SPC file and then parse the file. The question is: how such thing can be best implemented. Probably 
the file format itself would need to gain a new logical meta information like `multiple_files`.

Best, 

Sebastian