### PR TITLE
Add support for Python Wheels and auto-upload new versions to PyPI

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Python Release
 
 on: [push, pull_request]
 
@@ -54,3 +54,38 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*.whl
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+#   upload_pypi:
+#     needs: [build_wheels, build_sdist]
+#     runs-on: ubuntu-latest
+#     # upload to PyPI on every tag starting with 'v'
+#     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+#     # alternatively, to publish when a GitHub Release is created, use the following rule:
+#     # if: github.event_name == 'release' && github.event.action == 'published'
+#     steps:
+#       - uses: actions/download-artifact@v2
+#         with:
+#           name: artifact
+#           path: dist
+
+#       - uses: pypa/gh-action-pypi-publish@master
+#         with:
+#           user: __token__
+#           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,47 +9,48 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]
-        python: [3.5,3.6,3.7,3.8]
+        python-version: [3.5,3.6,3.7,3.8]
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
-        name: Install Python
+        name: Install Python v${{ matrix.python-version }}
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Download Boost
-        run: |
-          python -c "import urllib.request;urllib.request.urlretrieve('https://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.zip/download', 'boost_1_60_0.zip')"
       - name: Install wheel and setuptools
         run: |
           python -m pip install --upgrade setuptools
           python -m pip install --upgrade wheel
+      - name: Download Boost
+        run: |
+          python -c "import urllib.request;urllib.request.urlretrieve('https://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.zip/download', 'boost_1_60_0.zip')"
       - name: Windows Build
         if: runner.os == 'Windows'
         run: |
           choco install -y -f microsoft-build-tools
           choco install -y -f swig --version=4.0.1
           Expand-Archive boost_1_60_0.zip
-          $startDir=$(pwd)
-          cd $GITHUB_WORKSPACE
-          python setup.py build_ext -I$startDir\boost_1_60_0\boost_1_60_0 bdist_wheel
+          $startDir=$(pwd).tostring()
+          cd $Env:GITHUB_WORKSPACE
+          $command="python setup.py build_ext -I"+$startDir+"\boost_1_60_0\boost_1_60_0\ bdist_wheel"
+          cmd.exe /c $command
       - name: Linux Build
-        if: runner.os == "Linux"
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get install -y swig unzip
-          unzip boost_1_60_0.zip
+          unzip -qq boost_1_60_0.zip
           startDir=$(pwd)
           
-          python setup.py build_ext -I$startDir/boost_1_60_0/boost_1_60_0 bdist_wheel
+          python setup.py build_ext -I$startDir/boost_1_60_0/ bdist_wheel
       - name: macOS Build
-        if: runner.os == "macOS"
+        if: runner.os == 'macOS'
         run: |
           brew install swig
           brew install unzip
-          unzip boost_1_60_0.zip
+          unzip -qq boost_1_60_0.zip
           startDir=$(pwd)
           cd $GITHUB_WORKSPACE
-          python setup.py build_ext -I$startDir/boost_1_60_0/boost_1_60_0 bdist_wheel
+          python setup.py build_ext -I$startDir/boost_1_60_0/ bdist_wheel
       - uses: actions/upload-artifact@v2
         with:
-          path: $GITHUB_WORKSPACE/dist/*.whl
+          path: ./dist/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+        python: [3.5,3.6,3.7,3.8]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Download Boost
+        run: |
+          python -c "import urllib.request;urllib.request.urlretrieve('https://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.zip/download', 'boost_1_60_0.zip')"
+      - name: Install wheel and setuptools
+        run: |
+          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade wheel
+      - name: Windows Build
+        if: runner.os == 'Windows'
+        run: |
+          choco install -y -f microsoft-build-tools
+          choco install -y -f swig --version=4.0.1
+          Expand-Archive boost_1_60_0.zip
+          $startDir=$(pwd)
+          cd $GITHUB_WORKSPACE
+          python setup.py build_ext -I$startDir\boost_1_60_0\boost_1_60_0 bdist_wheel
+      - name: Linux Build
+        if: runner.os == "Linux"
+        run: |
+          sudo apt-get install -y swig unzip
+          unzip boost_1_60_0.zip
+          startDir=$(pwd)
+          
+          python setup.py build_ext -I$startDir/boost_1_60_0/boost_1_60_0 bdist_wheel
+      - name: macOS Build
+        if: runner.os == "macOS"
+        run: |
+          brew install swig
+          brew install unzip
+          unzip boost_1_60_0.zip
+          startDir=$(pwd)
+          cd $GITHUB_WORKSPACE
+          python setup.py build_ext -I$startDir/boost_1_60_0/boost_1_60_0 bdist_wheel
+      - uses: actions/upload-artifact@v2
+        with:
+          path: $GITHUB_WORKSPACE/dist/*.whl

--- a/TODO
+++ b/TODO
@@ -8,4 +8,3 @@ Feel free to request a new format by creating a new issue there.
 
 Generally, all new formats wait for volunteers.
 Or at least for a code that could be adapted and included in this library.
-

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,14 @@
 # This setup.py builds xylib as a python extension, which is experimental.
 # The normal way of building xylib is using configure && make. Or cmake.
 long_description="""\
-This package is a collection of built wheels for xylib-py (https://pypi.org/project/xylib-py/), pending approval of a PR that would autoupload these wheels to that package.
-
-Original Description:
 xylib is a library for reading obscure file formats with data from
 powder diffraction, spectroscopy and other experimental methods.
 For the list of supported formats see https://github.com/wojdyr/xylib .
 
 This module includes bindings to xylib and xylib itself.
 The first two numbers in the version are the version of included xylib.
+
+Prerequisites for building: SWIG and Boost libraries (headers only).
 """
 from setuptools import setup
 from distutils.core import Extension
@@ -49,9 +48,9 @@ swig_opts = ['-c++', '-modern', '-modernargs']
 if sys.version_info[0] == 3:
     swig_opts += ['-py3']
 
-setup(name='xylib-py-wheels',
+setup(name='xylib-py',
       version='1.6.0',
-      description='Built wheels for xylib-py by Marcin Wojdyr',
+      description='Python bindings to xylib',
       long_description=long_description,
       classifiers=[
           'Development Status :: 5 - Production/Stable',
@@ -61,10 +60,10 @@ setup(name='xylib-py-wheels',
           'Topic :: Scientific/Engineering :: Chemistry',
           'Topic :: Software Development :: Libraries :: Python Modules',
           ],
-      author='Christopher Stallard',
-      author_email='christopher.stallard1@gmail.com',
+      author='Marcin Wojdyr',
+      author_email='wojdyr@gmail.com',
       license='LGPL2.1',
-      url='https://github.com/chris-stallard1/xylib',
+      url='https://github.com/wojdyr/xylib',
       ext_modules=[Extension('_xylib',
                              sources=sources,
                              language='c++',

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,15 @@
 # This setup.py builds xylib as a python extension, which is experimental.
 # The normal way of building xylib is using configure && make. Or cmake.
 long_description="""\
+This package is a collection of built wheels for xylib-py (https://pypi.org/project/xylib-py/), pending approval of a PR that would autoupload these wheels to that package.
+
+Original Description:
 xylib is a library for reading obscure file formats with data from
 powder diffraction, spectroscopy and other experimental methods.
 For the list of supported formats see https://github.com/wojdyr/xylib .
 
 This module includes bindings to xylib and xylib itself.
 The first two numbers in the version are the version of included xylib.
-
-Prerequisites for building: SWIG and Boost libraries (headers only).
 """
 from setuptools import setup
 from distutils.core import Extension
@@ -48,9 +49,9 @@ swig_opts = ['-c++', '-modern', '-modernargs']
 if sys.version_info[0] == 3:
     swig_opts += ['-py3']
 
-setup(name='xylib-py',
+setup(name='xylib-py-wheels',
       version='1.6.0',
-      description='Python bindings to xylib',
+      description='Built wheels for xylib-py by Marcin Wojdyr',
       long_description=long_description,
       classifiers=[
           'Development Status :: 5 - Production/Stable',
@@ -60,10 +61,10 @@ setup(name='xylib-py',
           'Topic :: Scientific/Engineering :: Chemistry',
           'Topic :: Software Development :: Libraries :: Python Modules',
           ],
-      author='Marcin Wojdyr',
-      author_email='wojdyr@gmail.com',
+      author='Christopher Stallard',
+      author_email='christopher.stallard1@gmail.com',
       license='LGPL2.1',
-      url='https://github.com/wojdyr/xylib',
+      url='https://github.com/chris-stallard1/xylib',
       ext_modules=[Extension('_xylib',
                              sources=sources,
                              language='c++',

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ The first two numbers in the version are the version of included xylib.
 
 Prerequisites for building: SWIG and Boost libraries (headers only).
 """
-
-from distutils.core import setup, Extension
+from setuptools import setup
+from distutils.core import Extension
 from distutils.command.sdist import sdist
 from glob import glob
 import sys
@@ -70,7 +70,6 @@ setup(name='xylib-py',
                              swig_opts=swig_opts,
                              include_dirs=['.'],
                              libraries=[])],
-      #package_dir={'': 'xylib'},
       py_modules=['xylib'],
       headers=headers,
       cmdclass={'build': CustomBuild})


### PR DESCRIPTION
I created a GitHub Action that will automatically build python wheels for this project on Windows, Linux (built on Ubuntu), and MacOS for Python 3.5+. It additionally creates a source distribution, and a final (currently commented out) job will upload all of the wheels and the source to PyPI whenever a new version of the project is released. setuptools is now used instead of distutils in setup.py in order to allow wheels to be built.